### PR TITLE
Create a new type of colibri rootfs build for the FRC

### DIFF
--- a/CONFIG
+++ b/CONFIG
@@ -1,4 +1,6 @@
 # Localisation definitions for building Colibri VF50 rootfs
+# type must be either sic or frc, depending on which card is the colibri in
+TYPE = sic
 
 # Location of DLS rootfs
 ROOTFS_TOP = /dls_sw/prod/targetOS/rootfs/1.15

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ REQUIRED_SYMBOLS += UPGRADE_ROOT
 REQUIRED_SYMBOLS += BINUTILS_DIR
 REQUIRED_SYMBOLS += COMPILER_PREFIX
 REQUIRED_SYMBOLS += SYSROOT
+REQUIRED_SYMBOLS += TYPE
 
 include CONFIG
 include $(TOOLCHAIN)
@@ -228,9 +229,12 @@ $(ZIMAGE): $(KERNEL_BUILD)/.config
 	$(MAKE_KERNEL) zImage
 	touch $@
 
-$(KERNEL_DTB): kernel/device-tree.dts kernel/dls-dps.dtsi
+$(KERNEL_DTS_DIR)/dls-device.dtsi: kernel/dls-$(TYPE).dtsi
+	cp -f $< $@
+
+$(KERNEL_DTB): kernel/device-tree.dts kernel/dls-common.dtsi $(KERNEL_DTS_DIR)/dls-device.dtsi
 	mkdir -p $(KERNEL_DTS_DIR)
-	cp $^ $(KERNEL_DTS_DIR)
+	cp kernel/device-tree.dts kernel/dls-common.dtsi $(KERNEL_DTS_DIR)
 	$(MAKE_KERNEL) device-tree.dtb
 
 kernel-menuconfig: $(KERNEL_BUILD)/.config

--- a/kernel/device-tree.dts
+++ b/kernel/device-tree.dts
@@ -9,7 +9,8 @@
 
 /dts-v1/;
 #include "vf500-colibri.dtsi"
-#include "dls-dps.dtsi"
+/* renamed dtsi from the specific card */
+#include "dls-device.dtsi"
 
 / {
     model = "Toradex Colibri VF50 on DLS Digital Power Supply";

--- a/kernel/dls-common.dtsi
+++ b/kernel/dls-common.dtsi
@@ -135,58 +135,8 @@
             >;
         };
 
-        pinctrl_dls_fpga1: fpga1grp {
-            fsl,pins = <
-                /* DPS ADC FPGA programming. */
-                VF610_PAD_PTC1__GPIO_46     0x0001      // ADC INIT B
-                VF610_PAD_PTD13__GPIO_92    0x0001      // ADC DONE
-                VF610_PAD_PTA12__GPIO_5     0x00ed      // ADC PROG B
-                VF610_PAD_PTD28__GPIO_66    0x00c1      // ADC DSO
-                VF610_PAD_PTD31__GPIO_63    0x00cd      // ADC CLK
-            >;
-        };
-
-        pinctrl_dls_fpga2: fpga2grp {
-            fsl,pins = <
-                /* Digital Interface FPGA programming. */
-                VF610_PAD_PTA17__GPIO_7     0x0001      // INIT B
-                VF610_PAD_PTE21__GPIO_126   0x0001      // DONE
-                VF610_PAD_PTE22__GPIO_127   0x00ed      // PROG B
-                VF610_PAD_PTE13__GPIO_118   0x00c1      // DSO
-                VF610_PAD_PTE14__GPIO_119   0x00cd      // CLK
-            >;
-        };
-
         pinctrl_hog_1: hoggrp-1 {
             fsl,pins = <>;
         };
-    };
-};
-
-/ {
-    load_dps: dfl@1 {
-        compatible = "dls,fpga_loader";
-        dev_name = "load_dps";
-        pinctrl-names = "default";
-        pinctrl-0 = <&pinctrl_dls_fpga1>;
-        init-gpios = <&gpio1 14 GPIO_ACTIVE_HIGH>;
-        done-gpios = <&gpio2 28 GPIO_ACTIVE_HIGH>;
-        prog-gpios = <&gpio0 5 GPIO_ACTIVE_HIGH>;
-        d0-gpios = <&gpio2 2 GPIO_ACTIVE_HIGH>;
-        clk-gpios = <&gpio1 31 GPIO_ACTIVE_HIGH>;
-        status = "okay";
-    };
-
-    load_sic: dfl@2 {
-        compatible = "dls,fpga_loader";
-        dev_name = "load_sic";
-        pinctrl-names = "default";
-        pinctrl-0 = <&pinctrl_dls_fpga2>;
-        init-gpios = <&gpio0 7 GPIO_ACTIVE_HIGH>;
-        done-gpios = <&gpio3 30 GPIO_ACTIVE_HIGH>;
-        prog-gpios = <&gpio3 31 GPIO_ACTIVE_HIGH>;
-        d0-gpios = <&gpio3 22 GPIO_ACTIVE_HIGH>;
-        clk-gpios = <&gpio3 23 GPIO_ACTIVE_HIGH>;
-        status = "okay";
     };
 };

--- a/kernel/dls-frc.dtsi
+++ b/kernel/dls-frc.dtsi
@@ -1,0 +1,31 @@
+#include "dls-common.dtsi"
+
+&iomuxc {
+    vf610-colibri {
+        pinctrl_dls_fpga: fpgagrp {
+            fsl,pins = <
+                /* Digital Interface FPGA programming. */
+                VF610_PAD_PTA17__GPIO_7     0x0001      // INIT B
+                VF610_PAD_PTE21__GPIO_126   0x0001      // DONE
+                VF610_PAD_PTE22__GPIO_127   0x00ed      // PROG B
+                VF610_PAD_PTE13__GPIO_118   0x00c1      // DSO
+                VF610_PAD_PTE14__GPIO_119   0x00cd      // CLK
+            >;
+        };
+    };
+};
+
+/ {
+    load_frc_dfl: dfl {
+        compatible = "dls,fpga_loader";
+        dev_name = "load_frc";
+        pinctrl-names = "default";
+        pinctrl-0 = <&pinctrl_dls_fpga>;
+        init-gpios = <&gpio0 7 GPIO_ACTIVE_HIGH>;
+        done-gpios = <&gpio3 30 GPIO_ACTIVE_HIGH>;
+        prog-gpios = <&gpio3 31 GPIO_ACTIVE_HIGH>;
+        d0-gpios = <&gpio3 22 GPIO_ACTIVE_HIGH>;
+        clk-gpios = <&gpio3 23 GPIO_ACTIVE_HIGH>;
+        status = "okay";
+    };
+};

--- a/kernel/dls-sic.dtsi
+++ b/kernel/dls-sic.dtsi
@@ -1,0 +1,55 @@
+#include "dls-common.dtsi"
+
+&iomuxc {
+    vf610-colibri {
+        pinctrl_dls_fpga1: fpga1grp {
+            fsl,pins = <
+                /* DPS ADC FPGA programming. */
+                VF610_PAD_PTC1__GPIO_46     0x0001      // ADC INIT B
+                VF610_PAD_PTD13__GPIO_92    0x0001      // ADC DONE
+                VF610_PAD_PTA12__GPIO_5     0x00ed      // ADC PROG B
+                VF610_PAD_PTD28__GPIO_66    0x00c1      // ADC DSO
+                VF610_PAD_PTD31__GPIO_63    0x00cd      // ADC CLK
+            >;
+        };
+
+        pinctrl_dls_fpga2: fpga2grp {
+            fsl,pins = <
+                /* Digital Interface FPGA programming. */
+                VF610_PAD_PTA17__GPIO_7     0x0001      // INIT B
+                VF610_PAD_PTE21__GPIO_126   0x0001      // DONE
+                VF610_PAD_PTE22__GPIO_127   0x00ed      // PROG B
+                VF610_PAD_PTE13__GPIO_118   0x00c1      // DSO
+                VF610_PAD_PTE14__GPIO_119   0x00cd      // CLK
+            >;
+        };
+    };
+};
+
+/ {
+    load_dps_dfl: dfl {
+        compatible = "dls,fpga_loader";
+        dev_name = "load_dps";
+        pinctrl-names = "default";
+        pinctrl-0 = <&pinctrl_dls_fpga1>;
+        init-gpios = <&gpio1 14 GPIO_ACTIVE_HIGH>;
+        done-gpios = <&gpio2 28 GPIO_ACTIVE_HIGH>;
+        prog-gpios = <&gpio0 5 GPIO_ACTIVE_HIGH>;
+        d0-gpios = <&gpio2 2 GPIO_ACTIVE_HIGH>;
+        clk-gpios = <&gpio1 31 GPIO_ACTIVE_HIGH>;
+        status = "okay";
+    };
+
+    load_sic_dfl: dfl {
+        compatible = "dls,fpga_loader";
+        dev_name = "load_sic";
+        pinctrl-names = "default";
+        pinctrl-0 = <&pinctrl_dls_fpga2>;
+        init-gpios = <&gpio0 7 GPIO_ACTIVE_HIGH>;
+        done-gpios = <&gpio3 30 GPIO_ACTIVE_HIGH>;
+        prog-gpios = <&gpio3 31 GPIO_ACTIVE_HIGH>;
+        d0-gpios = <&gpio3 22 GPIO_ACTIVE_HIGH>;
+        clk-gpios = <&gpio3 23 GPIO_ACTIVE_HIGH>;
+        status = "okay";
+    };
+};


### PR DESCRIPTION
Each card requires a different device tree to consider the different FPGAs and the way to load it. A parameter called TYPE is defined in CONFIG to select between `sic` and `frc`